### PR TITLE
Fix segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Generated subdirectories
 /results/
+**/*.o
+**/*.so

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ EXTRA_CLEAN = sql/odbc_fdw.sql expected/odbc_fdw.out
 
 SHLIB_LINK = -lodbc
 
+ifdef DEBUG
+override CFLAGS += -DDEBUG -g -O0
+endif
+
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README
+++ b/README
@@ -15,8 +15,8 @@ A list of driver managers is available here: http://en.wikipedia.org/wiki/Open_D
 
 Once that's done, the extension can be built with:
 
-PATH=/usr/local/pgsql91/bin/:$PATH make USE_PGXS=1 make
-sudo PATH=/usr/local/pgsql91/bin/:$PATH make USE_PGXS=1 install
+PATH=$(pg_config --bindir):$PATH make USE_PGXS=1
+sudo PATH=$(pg_config --bindir):$PATH make USE_PGXS=1 install
 
 (assuming you have PostgreSQL 9.1 in /usr/local/pgsql91).
 

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -859,7 +859,10 @@ static ForeignScan* odbcGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel,
 			));
 	#endif
 	
-	return make_foreignscan(tlist, scan_clauses, scan_relid, NIL, NIL);
+	return make_foreignscan(tlist, scan_clauses,
+                                scan_relid, NIL, NIL,
+                                NIL /* fdw_scan_tlist */, NIL, /* fdw_recheck_quals */
+                                NIL /* outer_plan */ );
 }
 
 /* routines for versions older than 9.2.0 */

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -406,7 +406,7 @@ odbcGetOptions(Oid foreigntableid, char **svr_dsn, char **svr_database, char **s
     }
 
 #ifdef DEBUG
-    elog(NOTICE, "list length: %i", (*mapping_list)->length);
+    //elog(NOTICE, "list length: %i", (*mapping_list)->length);
 #endif
 
     /* Default values, if required */

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -815,7 +815,7 @@ static void odbcGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid fore
 	
 	add_path(baserel, 
 		(Path *) create_foreignscan_path(root, baserel, baserel->rows, startup_cost, total_cost,
-			NIL, NULL, NIL));
+			NIL, NULL, NIL, NIL /* no fdw_private list */));
 	
 	#ifdef DEBUG
 		ereport(NOTICE,

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1223,7 +1223,7 @@ odbcIterateForeignScan(ForeignScanState *node)
         SQLSMALLINT	NullablePtr;
         int i;
         int k;
-        bool found = FALSE;
+        bool found;
 
         /* Allocate memory for the masks */
         col_position_mask = NIL;
@@ -1232,6 +1232,7 @@ odbcIterateForeignScan(ForeignScanState *node)
         /* Obtain the column information of the first row. */
         for (i = 1; i <= columns; i++)
         {
+            found = FALSE;
             ColumnName = (SQLCHAR *) palloc(sizeof(SQLCHAR) * 255);
             SQLDescribeCol(stmt,
                            i,						/* ColumnName */


### PR DESCRIPTION
Fix bug causing segfaults with query columns not present in foreign table

The `found` variable retained the last column value as default value for next column, so missing columns where not detected and the size of the col_position_mask and col_size_array could be inconsistent with the number of columns.
